### PR TITLE
Removing BehaviorsXamlSDKManaged and replacing with Microsoft.Xaml.Be…

### DIFF
--- a/PhotoSharingApp/PhotoSharingApp.Universal.Tests/PhotoSharingApp.Universal.Tests.csproj
+++ b/PhotoSharingApp/PhotoSharingApp.Universal.Tests/PhotoSharingApp.Universal.Tests.csproj
@@ -92,9 +92,6 @@
   <ItemGroup>
     <!--A reference to the entire .Net Framework and Windows SDK are automatically included-->
     <None Include="project.json" />
-    <SDKReference Include="BehaviorsXamlSDKManaged, Version=12.0">
-      <Name>Behaviors SDK %28XAML%29</Name>
-    </SDKReference>
     <SDKReference Include="MSTestFramework.Universal, Version=$(UnitTestPlatformVersion)" />
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />
   </ItemGroup>

--- a/PhotoSharingApp/PhotoSharingApp.Universal.Tests/project.json
+++ b/PhotoSharingApp/PhotoSharingApp.Universal.Tests/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
+    "Microsoft.Xaml.Behaviors.Uwp.Managed": "2.0.0"
   },
   "frameworks": {
     "uap10.0": {}

--- a/PhotoSharingApp/PhotoSharingApp.Universal/PhotoSharingApp.Universal.csproj
+++ b/PhotoSharingApp/PhotoSharingApp.Universal/PhotoSharingApp.Universal.csproj
@@ -535,9 +535,6 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="BehaviorsXamlSDKManaged, Version=12.0">
-      <Name>Behaviors SDK %28XAML%29</Name>
-    </SDKReference>
     <SDKReference Include="WindowsMobile, Version=10.0.14393.0">
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>

--- a/PhotoSharingApp/PhotoSharingApp.Universal/project.json
+++ b/PhotoSharingApp/PhotoSharingApp.Universal/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.Azure.Mobile.Client": "2.0.1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
+    "Microsoft.Xaml.Behaviors.Uwp.Managed": "2.0.0",
     "Unity": "3.5.1404",
     "WindowsAzure.Messaging.Managed": "0.1.7.9",
     "WindowsAzure.Storage": "5.0.0"


### PR DESCRIPTION
For me this app isn't building natively in VS 2017. Removing BehaviorsXamlSDKManaged and replacing with Microsoft.Xaml.Behaviors.Uwp.Managed 2.0 seems to fix the build issues in the UWP and test projects.